### PR TITLE
Fix "Prefer `format()` over string interpolation operator" issue

### DIFF
--- a/lib/mysql_lib.py
+++ b/lib/mysql_lib.py
@@ -86,7 +86,7 @@ def get_all_mysql_grants():
                                              host=source_hosts)
 
             if key in grants.keys():
-                raise AuthError('Duplicate username defined for %s' % key)
+                raise AuthError('Duplicate username defined for {0!s}'.format(key))
             grants[key] = {'username': user['username'].encode('ascii', 'ignore'),
                            'password': user['password'].encode('ascii', 'ignore'),
                            'privileges': privileges.encode('ascii', 'ignore'),


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Prefer `format()` over string interpolation operator](https://www.quantifiedcode.com/app/issue_class/4ACGxFj1)
Issue details: [https://www.quantifiedcode.com/app/project/gh:runt18:mysql_utils?groups=code_patterns/%3A4ACGxFj1](https://www.quantifiedcode.com/app/project/gh:runt18:mysql_utils?groups=code_patterns/%3A4ACGxFj1)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Legal note: We won't claim any copyrights on the code changes.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)
